### PR TITLE
Page Control Color Customization

### DIFF
--- a/Sources/Pages/ModelPages.swift
+++ b/Sources/Pages/ModelPages.swift
@@ -41,6 +41,8 @@ public struct ModelPages<Data, Content>: View where Data: RandomAccessCollection
     private var hasControl: Bool
     private var pageControl: UIPageControl? = nil
     private var controlAlignment: Alignment
+    private var currentTintColor: UIColor
+    private var tintColor: UIColor
 
     /**
     Creates the paging view that generates pages dynamically based on some user-defined data.
@@ -86,7 +88,10 @@ public struct ModelPages<Data, Content>: View where Data: RandomAccessCollection
         hasControl: Bool = true,
         control: UIPageControl? = nil,
         controlAlignment: Alignment = .bottom,
+        currentTintColor: UIColor = .gray,
+        tintColor: UIColor = .white,
         template: @escaping (Int, Data.Element) -> Content
+        
     ) {
         self._currentPage = currentPage
         self.navigationOrientation = navigationOrientation
@@ -98,6 +103,8 @@ public struct ModelPages<Data, Content>: View where Data: RandomAccessCollection
         self.controlAlignment = controlAlignment
         self.items = items.map { $0 }
         self.template = template
+        self.currentTintColor = currentTintColor
+        self.tintColor = tintColor
     }
 
     public var body: some View {
@@ -118,6 +125,8 @@ public struct ModelPages<Data, Content>: View where Data: RandomAccessCollection
                 PageControl(
                     numberOfPages: items.count,
                     pageControl: pageControl,
+                    currentPageIndicatorTintColor: currentTintColor,
+                    pageIndicatorTintColor: tintColor,
                     currentPage: $currentPage
                 ).padding()
             }

--- a/Sources/Pages/ModelPages.swift
+++ b/Sources/Pages/ModelPages.swift
@@ -88,8 +88,8 @@ public struct ModelPages<Data, Content>: View where Data: RandomAccessCollection
         hasControl: Bool = true,
         control: UIPageControl? = nil,
         controlAlignment: Alignment = .bottom,
-        currentTintColor: UIColor = .gray,
-        tintColor: UIColor = .white,
+        currentTintColor: UIColor = .white,
+        tintColor: UIColor = .gray,
         template: @escaping (Int, Data.Element) -> Content
         
     ) {

--- a/Sources/Pages/PageControl.swift
+++ b/Sources/Pages/PageControl.swift
@@ -31,6 +31,8 @@ import UIKit
 internal struct PageControl: UIViewRepresentable {
     var numberOfPages: Int
     var pageControl: UIPageControl?
+    var currentPageIndicatorTintColor: UIColor
+    var pageIndicatorTintColor: UIColor
     @Binding var currentPage: Int
 
     func makeCoordinator() -> PageControlCoordinator {
@@ -43,6 +45,8 @@ internal struct PageControl: UIViewRepresentable {
         } else {
             let control = UIPageControl()
             control.numberOfPages = numberOfPages
+            control.currentPageIndicatorTintColor = currentPageIndicatorTintColor
+            control.pageIndicatorTintColor = pageIndicatorTintColor
             control.addTarget(
                 context.coordinator,
                 action: #selector(Coordinator.updateCurrentPage(sender:)),

--- a/Sources/Pages/PageViewController.swift
+++ b/Sources/Pages/PageViewController.swift
@@ -68,7 +68,7 @@ struct PageViewController: UIViewControllerRepresentable {
         pageViewController.setViewControllers(
             [controllers[currentPage]],
             direction: currentPage - previousPage > 0 ? .forward : .reverse,
-            animated: true
+            animated: false
         )
     }
 

--- a/Sources/Pages/Pages.swift
+++ b/Sources/Pages/Pages.swift
@@ -81,8 +81,8 @@ public struct Pages: View {
         hasControl: Bool = true,
         control: UIPageControl? = nil,
         controlAlignment: Alignment = .bottom,
-        currentTintColor: UIColor = .gray,
-        tintColor: UIColor = .white,
+        currentTintColor: UIColor = .white,
+        tintColor: UIColor = .gray,
         @PagesBuilder pages: () -> [AnyView]
                       
     ) {

--- a/Sources/Pages/Pages.swift
+++ b/Sources/Pages/Pages.swift
@@ -29,10 +29,10 @@ import UIKit
 /// A paging view that generates user-defined static pages.
 @available(iOS 13.0, *)
 public struct Pages: View {
-
+    
     @Binding var currentPage: Int
     var pages: [AnyView]
-
+    
     var navigationOrientation: UIPageViewController.NavigationOrientation
     var transitionStyle: UIPageViewController.TransitionStyle
     var bounce: Bool
@@ -40,36 +40,38 @@ public struct Pages: View {
     var hasControl: Bool
     var pageControl: UIPageControl? = nil
     var controlAlignment: Alignment
-
+     var currentTintColor: UIColor
+     var tintColor: UIColor
+    
     /**
-    Creates the paging view that generates user-defined static pages.
-
-    `Pages` can be used as follows:
-       ```
-           struct WelcomeView: View {
-
-               @State var index: Int = 0
-
-               var body: some View {
-                   Pages(currentPage: $index) {
-                        Text("Welcome! This is Page 1")
-                        Text("This is Page 2")
-                        Text("...and this is Page 3")
-                   }
-               }
-           }
-       ```
-
-       - Parameters:
-           - navigationOrientation: Whether to paginate horizontally or vertically.
-           - transitionStyle: Whether to perform a page curl or a scroll effect on page turn.
-           - bounce: Whether to bounce back when a user tries to scroll past all the pages.
-           - wrap: A flag indicating whether to wrap the pages circularly when the user scrolls past the beginning or end.
-           - hasControl: Whether to display a page control or not.
-           - control: A user defined page control.
-           - controlAlignment: What position to put the page control.
-           - pages: A function builder `PagesBuilder` that will put the views defined by the user on a list.
-    */
+     Creates the paging view that generates user-defined static pages.
+     
+     `Pages` can be used as follows:
+     ```
+     struct WelcomeView: View {
+     
+     @State var index: Int = 0
+     
+     var body: some View {
+     Pages(currentPage: $index) {
+     Text("Welcome! This is Page 1")
+     Text("This is Page 2")
+     Text("...and this is Page 3")
+     }
+     }
+     }
+     ```
+     
+     - Parameters:
+     - navigationOrientation: Whether to paginate horizontally or vertically.
+     - transitionStyle: Whether to perform a page curl or a scroll effect on page turn.
+     - bounce: Whether to bounce back when a user tries to scroll past all the pages.
+     - wrap: A flag indicating whether to wrap the pages circularly when the user scrolls past the beginning or end.
+     - hasControl: Whether to display a page control or not.
+     - control: A user defined page control.
+     - controlAlignment: What position to put the page control.
+     - pages: A function builder `PagesBuilder` that will put the views defined by the user on a list.
+     */
     public init(
         currentPage: Binding<Int>,
         navigationOrientation: UIPageViewController.NavigationOrientation = .horizontal,
@@ -79,7 +81,10 @@ public struct Pages: View {
         hasControl: Bool = true,
         control: UIPageControl? = nil,
         controlAlignment: Alignment = .bottom,
+        currentTintColor: UIColor = .gray,
+        tintColor: UIColor = .white,
         @PagesBuilder pages: () -> [AnyView]
+                      
     ) {
         self.navigationOrientation = navigationOrientation
         self.transitionStyle = transitionStyle
@@ -88,10 +93,13 @@ public struct Pages: View {
         self.hasControl = hasControl
         self.pageControl = control
         self.controlAlignment = controlAlignment
+        self.currentTintColor = currentTintColor
+        self.tintColor = tintColor
         self.pages = pages()
         self._currentPage = currentPage
+        
     }
-
+    
     public var body: some View {
         ZStack(alignment: self.controlAlignment) {
             PageViewController(
@@ -110,6 +118,8 @@ public struct Pages: View {
                 PageControl(
                     numberOfPages: pages.count,
                     pageControl: pageControl,
+                    currentPageIndicatorTintColor: currentTintColor,
+                    pageIndicatorTintColor: tintColor,
                     currentPage: $currentPage
                 ).padding()
             }


### PR DESCRIPTION
Your Pages package was such a lifesaver! Very easy to use and exactly what I was looking for. I noticed, though, that the page control indicators weren't customizable, and they also didn't change color when I toggled from light appearance to dark appearance on the simulator. As a result, they were basically invisible in the light appearance mode. I added the option to customize those colors; you could change them to match your app's color scheme, and you could pass in custom colors that vary by appearance to solve the problem I mentioned. You would have to pass a color in as a UIColor, not a SwiftUI Color, but this is easily done.

Thanks again for this great resource!