### PR TITLE
Update the number of pages on UIPageControl in case they have changed

### DIFF
--- a/Sources/Pages/PageControl.swift
+++ b/Sources/Pages/PageControl.swift
@@ -54,6 +54,7 @@ internal struct PageControl: UIViewRepresentable {
 
     func updateUIView(_ uiView: UIPageControl, context: Context) {
         uiView.currentPage = self.currentPage
+        uiView.numberOfPages = self.numberOfPages
     }
 
 }

--- a/Sources/Pages/PageViewController.swift
+++ b/Sources/Pages/PageViewController.swift
@@ -65,6 +65,11 @@ struct PageViewController: UIViewControllerRepresentable {
         let previousPage = context.coordinator.parent.currentPage
         context.coordinator.parent = self
 
+        if currentPage == previousPage,
+           pageViewController.viewControllers != nil,
+           pageViewController.viewControllers?.count ?? 0 > 0 {
+            return
+        }
         pageViewController.setViewControllers(
             [controllers[currentPage]],
             direction: currentPage - previousPage > 0 ? .forward : .reverse,


### PR DESCRIPTION
This PR makes the UIPageControl instance know about changes to the number of pages (which seem to be correctly updated on the PageControl instance already).